### PR TITLE
Add --reset flag to clear database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pdb
 
 .code
+/.worktrees/

--- a/src/db.rs
+++ b/src/db.rs
@@ -21,7 +21,7 @@ impl Database {
         Ok(db)
     }
     
-    fn get_db_path() -> PathBuf {
+    pub fn get_db_path() -> PathBuf {
         if let Some(home) = home_dir() {
             home.join(".clog").join("clog.db")
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,9 @@ struct Args {
     
     #[arg(long, help = "Use verbose output format")]
     verbose: bool,
+
+    #[arg(long, help = "Clear the database and exit")]
+    reset: bool,
 }
 
 fn main() {
@@ -51,6 +54,18 @@ fn main() {
 }
 
 fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    // Handle reset early and exit without other operations
+    if args.reset {
+        let db_path = db::Database::get_db_path();
+        match std::fs::remove_file(&db_path) {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(Box::new(e)),
+        }
+        println!("✓ Database cleared");
+        return Ok(());
+    }
+
     let db = Database::new()?;
     
     // Only need PID for write operations


### PR DESCRIPTION
Implements #3.\n\n- Adds a  flag to the CLI\n- Handles reset early in  without initializing the DB\n- Deletes  if present; ignores missing file\n- Prints  and exits successfully\n\nBuild/test:\n-  succeeds\n- Manual check:\n  -  -> prints success\n  - Running again when DB is missing also prints success\n\n