### PR TITLE
Add --stream flag for real-time log monitoring (closes #4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 chrono = "0.4"
 sysinfo = "0.31"
 dirs = "5.0"
+ctrlc = "3.4"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
This PR implements issue #4.\n\n- Adds a new `--stream` flag to tail entries in real time (`tail -f`-style)\n- Prints the last 10 entries initially, then polls every 500ms\n- New DB method: `list_entries_since(last_id, repo, filter, today, session)`\n- Respects current repo filtering by default; `--all` streams across repos\n- Handles Ctrl+C gracefully via `ctrlc`\n\nManual test: \n- Start: `cargo run -- --stream`\n- In another shell: `cargo run -- --name test`, then `cargo run -- "hello"`\n- New messages appear in the stream in compact format.\n\nLet me know if you want streaming to honor `--verbose` output instead of compact-only.\n