### PR TITLE
Add support for inline log entry with --name flag (closes #5)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,13 +81,17 @@ fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             process::id()
         });
         
-        if let Some(name) = args.name {
-            handle_name_registration(&db, ppid, &name)?;
-            return Ok(());
+        // Handle both name and message if both are provided
+        if let Some(name) = &args.name {
+            handle_name_registration(&db, ppid, name)?;
+            // Only return if there's no message to log
+            if args.message.is_none() {
+                return Ok(());
+            }
         }
         
-        if let Some(message) = args.message {
-            handle_log_message(&db, ppid, &message)?;
+        if let Some(message) = &args.message {
+            handle_log_message(&db, ppid, message)?;
         }
     } else if args.stream {
         handle_stream_entries(&db, &args)?;


### PR DESCRIPTION
## Summary
Implements the ability to register/update session name and log a message in a single command:
```bash
clog --name <name> "message text"
```

## Changes
- Modified `run()` function logic in `src/main.rs` to handle both name registration and message logging when both flags are present
- The name registration happens first, followed by message logging
- Maintains backward compatibility - `clog --name <name>` without a message still works as before

## Testing
Tested locally:
```bash
# Reset database
./target/debug/clog --reset

# Test combined command
./target/debug/clog --name test-user "Testing inline name and message"
# Output:
# ✓ Session registered as 'test-user' (PID: 59018)
# ✓ Logged
# Recent entries:
# 21:43:05 [test-user] Testing inline name and message
```

## Benefits
- Reduces friction for first-time logging in a new session
- Eliminates need for two separate commands
- More intuitive user experience

Closes #5